### PR TITLE
Add constructors of enum that take member definitions

### DIFF
--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -35,6 +35,7 @@
 #include <typeinfo>
 #include <utility>
 #include <new>
+#include <vector>
 
 // Implementation. The nb_*.h files should only be included through nanobind.h
 // IWYU pragma: begin_exports

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -65,9 +65,19 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
 
     object enum_mod = module_::import_("enum"),
            factory = enum_mod.attr(factory_name),
-           result = factory(name, nanobind::tuple(),
+           result = factory(name, ed->members,
                             arg("module") = modname,
                             arg("qualname") = qualname);
+    // Set the `__doc__` attribute of each enum member.
+    {
+      auto member_iter{ed->members.begin()}, member_end_iter{ed->members.end()};
+      auto doc_iter{ed->member_docs.begin()}, doc_end_iter{ed->member_docs.end()};
+      while (member_iter != member_end_iter && doc_iter != doc_end_iter) {
+        result.attr((*member_iter)[0]).attr("__doc__") = *doc_iter;
+        ++member_iter;
+        ++doc_iter;
+      }
+    }
 
     scope.attr(name) = result;
     result.attr("__doc__") = ed->docstr ? str(ed->docstr) : none();

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -26,10 +26,17 @@ NB_MODULE(test_enum_ext, m) {
             .value("C", Flag::C, "Value C")
             .export_values();
 
-    nb::enum_<UnsignedFlag>(m, "UnsignedFlag", nb::is_flag())
-                .value("A", UnsignedFlag::A, "Value A")
-                .value("B", UnsignedFlag::B, "Value B")
-                .value("All", UnsignedFlag::All, "All values");
+    nb::enum_<UnsignedFlag>(
+        m,
+        nb::enum_init_with_members{},
+        "UnsignedFlag",
+        {
+            {"A", UnsignedFlag::A, "Value A"},
+            {"B", UnsignedFlag::B, "Value B"},
+            {"All", UnsignedFlag::All, "All values"}
+        },
+        nb::is_flag{}
+    );
 
     nb::enum_<SEnum>(m, "SEnum", nb::is_arithmetic())
         .value("A", SEnum::A)


### PR DESCRIPTION
The benefit of the new API is a simpler and safer implementation that uses only the public API of the Python Enum class, mimicking how it would be done in Python code. The exisiting API `value()` incrementally adds member to a Enum class, entailing modifying internal states of the Enum class.